### PR TITLE
Set advertized speed to 10gbps

### DIFF
--- a/drivers/net/tun.c
+++ b/drivers/net/tun.c
@@ -3523,7 +3523,7 @@ static void tun_default_link_ksettings(struct net_device *dev,
 {
 	ethtool_link_ksettings_zero_link_mode(cmd, supported);
 	ethtool_link_ksettings_zero_link_mode(cmd, advertising);
-	cmd->base.speed		= SPEED_10;
+	cmd->base.speed		= SPEED_10000;
 	cmd->base.duplex	= DUPLEX_FULL;
 	cmd->base.port		= PORT_TP;
 	cmd->base.phy_address	= 0;


### PR DESCRIPTION
https://lore.kernel.org/lkml/20221021114921.3705550-1-i.maximets@ovn.org/
Why hasn't this been considered yet?

This should fix a few fringe issues, and reduce bug reports.